### PR TITLE
Optionally leave lobbies open with zero players

### DIFF
--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/Implementations/BaseLobby.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/Implementations/BaseLobby.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Barebones.Networking;
 using UnityEngine;
+using Barebones.Logging;
 
 namespace Barebones.MasterServer
 {
@@ -16,6 +17,8 @@ namespace Barebones.MasterServer
         public event Action<LobbyMember> PlayerRemoved;
 
         public event Action<ILobby> Destroyed;
+
+        public BmLogger Logger = Msf.Create.Logger(typeof(BaseLobby).Name);
 
         protected Dictionary<string, LobbyMember> Members;
         protected Dictionary<int, LobbyMember> MembersByPeerId;
@@ -808,8 +811,11 @@ namespace Barebones.MasterServer
         protected virtual void OnPlayerRemoved(LobbyMember member)
         {
             // Destroy lobby if last member left
-            if (Members.Count == 0)
+            if (!Config.KeepAliveWithZeroPlayers && Members.Count == 0)
+            {
                 Destroy();
+                Logger.Log(LogLevel.Info, string.Format("Lobby \"{0}\" destroyed due to last player leaving.", Name));
+            }
 
             // Notify others about the user who left
             Broadcast(MessageHelper.Create((short)MsfOpCodes.LobbyMemberLeft, member.Username));

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/LobbyConfig.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/LobbyConfig.cs
@@ -42,6 +42,11 @@
         /// </summary>
         public bool EnableManualStart = true;
 
+        /// <summary>
+        /// If true, lobby will not destroy when last player leaves.
+        /// </summary>
+        public bool KeepAliveWithZeroPlayers = false;
+
         public bool AllowPlayersChangeLobbyProperties = true;
     }
 }


### PR DESCRIPTION
Some lobbies may have transient users - ones that come and go as they wish. Optionally, allow the lobby to stay open even if the last player leaves.