### PR TITLE
Customize error when a player is not allowed to join a lobby

### DIFF
--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/Implementations/BaseLobby.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Lobbies/Implementations/BaseLobby.cs
@@ -139,9 +139,12 @@ namespace Barebones.MasterServer
                 return false;
             }
 
-            if (!IsPlayerAllowed(username, playerExt))
+            if (!IsPlayerAllowed(username, playerExt, out error))
             {
-                error = "You're not allowed";
+                if (error == null || error == string.Empty)
+                {
+                    error = "You're not allowed";
+                }
                 return false;
             }
 
@@ -419,8 +422,9 @@ namespace Barebones.MasterServer
         /// This will be called before adding a player to lobby.
         /// Override it to add custom checks for bans and etc.
         /// </summary>
-        protected virtual bool IsPlayerAllowed(string username, LobbyUserExtension user)
+        protected virtual bool IsPlayerAllowed(string username, LobbyUserExtension user, out string error)
         {
+            error = "You're not allowed";
             return true;
         }
 


### PR DESCRIPTION
This PR modifies the signature of ``BaseLobby.IsPlayerAllowed`` to include an ``out string error`` parameter in order to be able to return an error instead of the default "Player is not allowed" message.

Since this introduces a breaking change for classes who extend ``BaseLobby``, maybe you'd prefer if it would be added as an overload instead. That'd be fine, just let me know and I can implement it, although I believe you'd want to give the user a hint of why he/she is not allowed to join, hence I prefer that the implementation forces you to do so.

Leo.