### PR TITLE
Observable Dictionaries refactor in order to avoid code repetition.

### DIFF
--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableBaseDictionary.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableBaseDictionary.cs
@@ -1,0 +1,222 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Barebones.Networking;
+
+namespace Barebones.MasterServer
+{
+    public abstract class ObservableBaseDictionary<TKey, TValue> : ObservableBase
+    {
+        private const int SetOperation = 0;
+        private const int RemoveOperation = 1;
+
+        private Dictionary<TKey, TValue> _values;
+
+        private Queue<UpdateEntry> _updates;
+
+        public ObservableBaseDictionary(short key) : this(key, null)
+        {
+        }
+
+        public ObservableBaseDictionary(short key, Dictionary<TKey, TValue> defaultValues) : base(key)
+        {
+            _updates = new Queue<UpdateEntry>();
+
+            _values = defaultValues == null ? new Dictionary<TKey, TValue>() :
+                defaultValues.ToDictionary(k => k.Key, k => k.Value);
+        }
+
+        /// <summary>
+        /// Returns an immutable list of values
+        /// </summary>
+        public IEnumerable<TValue> Values
+        {
+            get { return _values.Values; }
+        }
+
+        /// <summary>
+        /// Returns an immutable list of key-value pairs
+        /// </summary>
+        public IEnumerable<KeyValuePair<TKey, TValue>> Pairs
+        {
+            get { return _values.ToList(); }
+        }
+
+        /// <summary>
+        /// Returns a mutable dictionary
+        /// </summary>
+        public Dictionary<TKey, TValue> UnderlyingDictionary
+        {
+            get { return _values; }
+        }
+
+        public void SetValue(TKey key, TValue value)
+        {
+            if (value == null)
+            {
+                Remove(key);
+                return;
+            }
+
+            if (_values.ContainsKey(key))
+            {
+                _values[key] = value;
+            }
+            else
+            {
+                _values.Add(key, value);
+            }
+
+            MarkDirty();
+            _updates.Enqueue(new UpdateEntry()
+            {
+                Key = key,
+                Operation = SetOperation,
+                Value = value
+            });
+        }
+
+        public void Remove(TKey key)
+        {
+            _values.Remove(key);
+
+            MarkDirty();
+            _updates.Enqueue(new UpdateEntry()
+            {
+                Key = key,
+                Operation = RemoveOperation,
+            });
+        }
+
+        public TValue GetValue(TKey key)
+        {
+            TValue result;
+            _values.TryGetValue(key, out result);
+            return result;
+        }
+
+        protected abstract void WriteValue(TValue value, EndianBinaryWriter writer);
+
+        protected abstract TValue ReadValue(EndianBinaryReader reader);
+
+        protected abstract void WriteKey(TKey key, EndianBinaryWriter writer);
+
+        protected abstract TKey ReadKey(EndianBinaryReader reader);
+
+        public override byte[] ToBytes()
+        {
+            byte[] b;
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
+                {
+                    writer.Write(_values.Count);
+
+                    foreach (var item in _values)
+                    {
+                        WriteKey(item.Key, writer);
+                        WriteValue(item.Value, writer);
+                    }
+                }
+
+                b = ms.ToArray();
+            }
+            return b;
+        }
+
+        public override void FromBytes(byte[] data)
+        {
+            using (var ms = new MemoryStream(data))
+            {
+                using (var reader = new EndianBinaryReader(EndianBitConverter.Big, ms))
+                {
+                    var count = reader.ReadInt32();
+
+                    for (var i = 0; i < count; i++)
+                    {
+                        var key = ReadKey(reader);
+                        var value = ReadValue(reader);
+                        if (_values.ContainsKey(key))
+                        {
+                            _values[key] = value;
+                        }
+                        else
+                        {
+                            _values.Add(key, value);
+                        }
+                    }
+                }
+            }
+        }
+
+        public override byte[] GetUpdates()
+        {
+            using (var ms = new MemoryStream())
+            {
+                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
+                {
+                    writer.Write(_updates.Count);
+
+                    foreach (var update in _updates)
+                    {
+                        writer.Write(update.Operation);
+                        WriteKey(update.Key, writer);
+
+                        if (update.Operation != RemoveOperation)
+                        {
+                            WriteValue(update.Value, writer);
+                        }
+                    }
+                }
+                return ms.ToArray();
+            }
+        }
+
+        public override void ApplyUpdates(byte[] data)
+        {
+            using (var ms = new MemoryStream(data))
+            {
+                using (var reader = new EndianBinaryReader(EndianBitConverter.Big,ms))
+                {
+                    var count = reader.ReadInt32();
+
+                    for (var i = 0; i < count; i++)
+                    {
+                        var operation = reader.ReadByte();
+                        var key = ReadKey(reader);
+                        
+                        if (operation == RemoveOperation)
+                        {
+                            
+                            _values.Remove(key);
+                            continue;
+                        }
+
+                        var value = ReadValue(reader);
+                        if (_values.ContainsKey(key))
+                        {
+                            _values[key] = value;
+                        }
+                        else
+                        {
+                            _values.Add(key, value);
+                        }
+                    }
+                }
+            }
+            MarkDirty();
+        }
+
+        public override void ClearUpdates()
+        {
+            _updates.Clear();
+        }
+
+        private struct UpdateEntry
+        {
+            public byte Operation;
+            public TKey Key;
+            public TValue Value;
+        }
+    }
+}

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableBaseDictionary.cs.meta
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableBaseDictionary.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 427567737cd16704d94cc0b805ac563a
+timeCreated: 1505149222
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictStringFloat.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictStringFloat.cs
@@ -1,109 +1,25 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Barebones.Networking;
 
 namespace Barebones.MasterServer
 {
-    public class ObservableDictStringFloat : ObservableBase
+    public class ObservableDictStringFloat : ObservableBaseDictionary<string,float>
     {
-        private const int SetOperation = 0;
-        private const int RemoveOperation = 1;
-
-        private Dictionary<string, float> _values;
-
-        private Queue<UpdateEntry> _updates;
-
-        public ObservableDictStringFloat(short key) : this(key, null)
+        public ObservableDictStringFloat(short key) 
+            : base(key)
         {
         }
 
-        public ObservableDictStringFloat(short key, Dictionary<string, float> defaultValues) : base(key)
+        public ObservableDictStringFloat(short key, Dictionary<string, float> defaultValues) 
+            : base(key, defaultValues)
         {
-            _updates = new Queue<UpdateEntry>();
-
-            _values = defaultValues == null ? new Dictionary<string, float>() :
-                defaultValues.ToDictionary(k => k.Key, k => k.Value);
-        }
-
-        /// <summary>
-        /// Returns an immutable list of values
-        /// </summary>
-        public IEnumerable<float> Values
-        {
-            get { return _values.Values; }
-        }
-
-        /// <summary>
-        /// Returns an immutable list of key-value pairs
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, float>> Pairs
-        {
-            get { return _values.ToList(); }
-        }
-
-        /// <summary>
-        /// Returns a mutable dictionary
-        /// </summary>
-        public Dictionary<string, float> UnderlyingDictionary
-        {
-            get { return _values; }
-        }
-
-        public void SetValue(string key, float value)
-        {
-            if (_values.ContainsKey(key))
-            {
-                _values[key] = value;
-            }
-            else
-            {
-                _values.Add(key, value);
-            }
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = SetOperation,
-                Value = value
-            });
-        }
-
-        public void Remove(string key)
-        {
-            _values.Remove(key);
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = RemoveOperation,
-            });
-        }
-
-        public float GetValue(string key)
-        {
-            float result;
-            _values.TryGetValue(key, out result);
-            return result;
-        }
-
-        public override byte[] ToBytes()
-        {
-            return _values.ToBytes();
-        }
-
-        public override void FromBytes(byte[] data)
-        {
-            _values.FromBytes(data);
         }
 
         public override string SerializeToString()
         {
             var obj = new JSONObject();
 
-            foreach (var pair in _values)
+            foreach (var pair in UnderlyingDictionary)
             {
                 obj.AddField(pair.Key, pair.Value);
             }
@@ -122,78 +38,28 @@ namespace Barebones.MasterServer
 
             for (var i = 0; i < keys.Count; i++)
             {
-                _values[keys[i]] = list[i].f;
+                UnderlyingDictionary[keys[i]] = list[i].f;
             }
         }
 
-        public override byte[] GetUpdates()
+        protected override void WriteValue(float value, EndianBinaryWriter writer)
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
-                {
-                    writer.Write(_updates.Count);
-
-                    foreach (var update in _updates)
-                    {
-                        writer.Write(update.Operation);
-                        writer.Write(update.Key);
-
-                        if (update.Operation != RemoveOperation)
-                        {
-                            writer.Write(update.Value);
-                        }
-                    }
-                }
-                return ms.ToArray();
-            }
+            writer.Write(value);
         }
 
-        public override void ApplyUpdates(byte[] data)
+        protected override float ReadValue(EndianBinaryReader reader)
         {
-            using (var ms = new MemoryStream(data))
-            {
-                using (var reader = new EndianBinaryReader(EndianBitConverter.Big, ms))
-                {
-                    var count = reader.ReadInt32();
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        var operation = reader.ReadByte();
-                        var key = reader.ReadString();
-
-                        if (operation == RemoveOperation)
-                        {
-                            _values.Remove(key);
-                            continue;
-                        }
-
-                        var value = reader.ReadSingle();
-
-                        if (_values.ContainsKey(key))
-                        {
-                            _values[key] = value;
-                        }
-                        else
-                        {
-                            _values.Add(key, value);
-                        }
-                    }
-                }
-            }
-            MarkDirty();
+            return reader.ReadSingle();
         }
 
-        public override void ClearUpdates()
+        protected override void WriteKey(string key, EndianBinaryWriter writer)
         {
-            _updates.Clear();
+            writer.Write(key);
         }
 
-        private struct UpdateEntry
+        protected override string ReadKey(EndianBinaryReader reader)
         {
-            public byte Operation;
-            public string Key;
-            public float Value;
+            return reader.ReadString();
         }
     }
 }

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictStringInt.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictStringInt.cs
@@ -1,109 +1,25 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Barebones.Networking;
 
 namespace Barebones.MasterServer
 {
-    public class ObservableDictStringInt : ObservableBase
+    public class ObservableDictStringInt : ObservableBaseDictionary<string, int>
     {
-        private const int SetOperation = 0;
-        private const int RemoveOperation = 1;
-
-        private Dictionary<string, int> _values;
-
-        private Queue<UpdateEntry> _updates;
-
-        public ObservableDictStringInt(short key) : this(key, null)
+        public ObservableDictStringInt(short key) 
+            : base(key)
         {
         }
 
-        public ObservableDictStringInt(short key, Dictionary<string, int> defaultValues) : base(key)
+        public ObservableDictStringInt(short key, Dictionary<string, int> defaultValues) 
+            : base(key, defaultValues)
         {
-            _updates = new Queue<UpdateEntry>();
-
-            _values = defaultValues == null ? new Dictionary<string, int>() :
-                defaultValues.ToDictionary(k => k.Key, k => k.Value);
-        }
-
-        /// <summary>
-        /// Returns an immutable list of values
-        /// </summary>
-        public IEnumerable<int> Values
-        {
-            get { return _values.Values; }
-        }
-
-        /// <summary>
-        /// Returns an immutable list of key-value pairs
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, int>> Pairs
-        {
-            get { return _values.ToList(); }
-        }
-
-        /// <summary>
-        /// Returns a mutable dictionary
-        /// </summary>
-        public Dictionary<string, int> UnderlyingDictionary
-        {
-            get { return _values; }
-        }
-
-        public void SetValue(string key, int value)
-        {
-            if (_values.ContainsKey(key))
-            {
-                _values[key] = value;
-            }
-            else
-            {
-                _values.Add(key, value);
-            }
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = SetOperation,
-                Value = value
-            });
-        }
-
-        public void Remove(string key)
-        {
-            _values.Remove(key);
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = RemoveOperation,
-            });
-        }
-
-        public int GetValue(string key)
-        {
-            int result;
-            _values.TryGetValue(key, out result);
-            return result;
-        }
-
-        public override byte[] ToBytes()
-        {
-            return _values.ToBytes();
-        }
-
-        public override void FromBytes(byte[] data)
-        {
-            _values.FromBytes(data);
         }
 
         public override string SerializeToString()
         {
             var obj = new JSONObject();
 
-            foreach (var pair in _values)
+            foreach (var pair in UnderlyingDictionary)
             {
                 obj.AddField(pair.Key, pair.Value);
             }
@@ -122,78 +38,28 @@ namespace Barebones.MasterServer
 
             for (var i = 0; i < keys.Count; i++)
             {
-                _values[keys[i]] = (int) list[i].i;
+                UnderlyingDictionary[keys[i]] = (int)list[i].i;
             }
         }
 
-        public override byte[] GetUpdates()
+        protected override string ReadKey(EndianBinaryReader reader)
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
-                {
-                    writer.Write(_updates.Count);
-
-                    foreach (var update in _updates)
-                    {
-                        writer.Write(update.Operation);
-                        writer.Write(update.Key);
-
-                        if (update.Operation != RemoveOperation)
-                        {
-                            writer.Write(update.Value);
-                        }
-                    }
-                }
-                return ms.ToArray();
-            }
+            return reader.ReadString();
         }
 
-        public override void ApplyUpdates(byte[] data)
+        protected override int ReadValue(EndianBinaryReader reader)
         {
-            using (var ms = new MemoryStream(data))
-            {
-                using (var reader = new EndianBinaryReader(EndianBitConverter.Big, ms))
-                {
-                    var count = reader.ReadInt32();
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        var operation = reader.ReadByte();
-                        var key = reader.ReadString();
-
-                        if (operation == RemoveOperation)
-                        {
-                            _values.Remove(key);
-                            continue;
-                        }
-
-                        var value = reader.ReadInt32();
-
-                        if (_values.ContainsKey(key))
-                        {
-                            _values[key] = value;
-                        }
-                        else
-                        {
-                            _values.Add(key, value);
-                        }
-                    }
-                }
-            }
-            MarkDirty();
+            return reader.ReadInt32();
         }
 
-        public override void ClearUpdates()
+        protected override void WriteKey(string key, EndianBinaryWriter writer)
         {
-            _updates.Clear();
+            writer.Write(key);
         }
 
-        private struct UpdateEntry
+        protected override void WriteValue(int value, EndianBinaryWriter writer)
         {
-            public byte Operation;
-            public string Key;
-            public int Value;
+            writer.Write(value);
         }
     }
 }

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictionary.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictionary.cs
@@ -1,115 +1,25 @@
 ﻿using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Barebones.Networking;
 
 namespace Barebones.MasterServer
 {
-    public class ObservableDictionary : ObservableBase
+    public class ObservableDictionary : ObservableBaseDictionary<string,string>
     {
-        private const int SetOperation = 0;
-        private const int RemoveOperation = 1;
-
-        private Dictionary<string, string> _values;
-
-        private Queue<UpdateEntry> _updates;
-
-        public ObservableDictionary(short key) : this(key, null)
+        public ObservableDictionary(short key)
+            : base(key)
         {
         }
 
-        public ObservableDictionary(short key, Dictionary<string, string> defaultValues) : base(key)
+        public ObservableDictionary(short key, Dictionary<string, string> defaultValues) 
+            : base(key, defaultValues)
         {
-            _updates = new Queue<UpdateEntry>();
-
-            _values = defaultValues == null ? new Dictionary<string, string>() :
-                defaultValues.ToDictionary(k => k.Key, k => k.Value);
-        }
-
-        /// <summary>
-        /// Returns an immutable list of values
-        /// </summary>
-        public IEnumerable<string> Values
-        {
-            get { return _values.Values; }
-        }
-
-        /// <summary>
-        /// Returns an immutable list of key-value pairs
-        /// </summary>
-        public IEnumerable<KeyValuePair<string, string>> Pairs
-        {
-            get { return _values.ToList(); }
-        }
-
-        /// <summary>
-        /// Returns a mutable dictionary
-        /// </summary>
-        public Dictionary<string, string> UnderlyingDictionary
-        {
-            get { return _values; }
-        }
-
-        public void SetValue(string key, string value)
-        {
-            if (value == null)
-            {
-                Remove(key);
-                return;
-            }
-
-            if (_values.ContainsKey(key))
-            {
-                _values[key] = value;
-            }
-            else
-            {
-                _values.Add(key, value);
-            }
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation =  SetOperation,
-                Value = value
-            });
-        }
-
-        public void Remove(string key)
-        {
-            _values.Remove(key);
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = RemoveOperation,
-            });
-        }
-
-        public string GetValue(string key)
-        {
-            string result;
-            _values.TryGetValue(key, out result);
-            return result;
-        }
-
-        public override byte[] ToBytes()
-        {
-            return _values.ToBytes();
-        }
-
-        public override void FromBytes(byte[] data)
-        {
-            _values.FromBytes(data);
         }
 
         public override string SerializeToString()
         {
             var obj = new JSONObject();
 
-            foreach (var pair in _values)
+            foreach (var pair in UnderlyingDictionary)
             {
                 obj.AddField(pair.Key, pair.Value);
             }
@@ -128,78 +38,28 @@ namespace Barebones.MasterServer
 
             for (var i = 0; i < keys.Count; i++)
             {
-                _values[keys[i]] = list[i].str;
+                UnderlyingDictionary[keys[i]] = list[i].str;
             }
         }
 
-        public override byte[] GetUpdates()
+        protected override void WriteValue(string value, EndianBinaryWriter writer)
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
-                {
-                    writer.Write(_updates.Count);
-
-                    foreach (var update in _updates)
-                    {
-                        writer.Write(update.Operation);
-                        writer.Write(update.Key);
-
-                        if (update.Operation != RemoveOperation)
-                        {
-                            writer.Write(update.Value);
-                        }
-                    }
-                }
-                return ms.ToArray();
-            }
+            writer.Write(value);
         }
 
-        public override void ApplyUpdates(byte[] data)
+        protected override string ReadValue(EndianBinaryReader reader)
         {
-            using (var ms = new MemoryStream(data))
-            {
-                using (var reader = new EndianBinaryReader(EndianBitConverter.Big,ms))
-                {
-                    var count = reader.ReadInt32();
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        var operation = reader.ReadByte();
-                        var key = reader.ReadString();
-
-                        if (operation == RemoveOperation)
-                        {
-                            _values.Remove(key);
-                            continue;
-                        }
-
-                        var value = reader.ReadString();
-
-                        if (_values.ContainsKey(key))
-                        {
-                            _values[key] = value;
-                        }
-                        else
-                        {
-                            _values.Add(key, value);
-                        }
-                    }
-                }
-            }
-            MarkDirty();
+            return reader.ReadString();
         }
 
-        public override void ClearUpdates()
+        protected override void WriteKey(string key, EndianBinaryWriter writer)
         {
-            _updates.Clear();
+            writer.Write(key);
         }
 
-        private struct UpdateEntry
+        protected override string ReadKey(EndianBinaryReader reader)
         {
-            public byte Operation;
-            public string Key;
-            public string Value;
+            return reader.ReadString();
         }
     }
 }

--- a/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictionaryInt.cs
+++ b/MasterServerFramework2/Assets/Barebones/Msf/Scripts/Modules/Profiles/ObservableDictionaryInt.cs
@@ -1,110 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+﻿using System.Collections.Generic;
 using Barebones.Networking;
 
 namespace Barebones.MasterServer
 {
-    public class ObservableDictionaryInt : ObservableBase
+    public class ObservableDictionaryInt : ObservableBaseDictionary<int,int>
     {
-        private const int SetOperation = 0;
-        private const int RemoveOperation = 1;
-
-        private Dictionary<int, int> _values;
-
-        private Queue<UpdateEntry> _updates;
-
-        public ObservableDictionaryInt(short key) : this(key, null)
+        public ObservableDictionaryInt(short key) 
+            : base(key)
         {
         }
 
-        public ObservableDictionaryInt(short key, Dictionary<int, int> defaultValues) : base(key)
+        public ObservableDictionaryInt(short key, Dictionary<int, int> defaultValues) 
+            : base(key, defaultValues)
         {
-            _updates = new Queue<UpdateEntry>();
-
-            _values = defaultValues == null ? new Dictionary<int, int>() :
-                defaultValues.ToDictionary(k => k.Key, k => k.Value);
-        }
-
-        /// <summary>
-        /// Returns an immutable list of values
-        /// </summary>
-        public IEnumerable<int> Values
-        {
-            get { return _values.Values; }
-        }
-
-        /// <summary>
-        /// Returns an immutable list of key-value pairs
-        /// </summary>
-        public IEnumerable<KeyValuePair<int, int>> Pairs
-        {
-            get { return _values.ToList(); }
-        }
-
-        /// <summary>
-        /// Returns a mutable dictionary
-        /// </summary>
-        public Dictionary<int, int> UnderlyingDictionary
-        {
-            get { return _values; }
-        }
-
-        public void SetValue(int key, int value)
-        {
-            if (_values.ContainsKey(key))
-            {
-                _values[key] = value;
-            }
-            else
-            {
-                _values.Add(key, value);
-            }
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation =  SetOperation,
-                Value = value
-            });
-        }
-
-        public void Remove(int key)
-        {
-            _values.Remove(key);
-
-            MarkDirty();
-            _updates.Enqueue(new UpdateEntry()
-            {
-                Key = key,
-                Operation = RemoveOperation,
-            });
-        }
-
-        public int GetValue(int key)
-        {
-            int result;
-            _values.TryGetValue(key, out result);
-            return result;
-        }
-
-        public override byte[] ToBytes()
-        {
-            return _values.ToBytes();
-        }
-
-        public override void FromBytes(byte[] data)
-        {
-            _values.FromBytes(data);
         }
 
         public override string SerializeToString()
         {
             var obj = new JSONObject();
 
-            foreach (var pair in _values)
+            foreach (var pair in UnderlyingDictionary)
             {
                 obj.AddField(pair.Key.ToString(), pair.Value);
             }
@@ -123,81 +38,28 @@ namespace Barebones.MasterServer
 
             for (var i = 0; i < keys.Count; i++)
             {
-                _values[int.Parse(keys[i])] = (int)list[i].i;
+                UnderlyingDictionary[int.Parse(keys[i])] = (int)list[i].i;
             }
         }
 
-        public override byte[] GetUpdates()
+        protected override void WriteValue(int value, EndianBinaryWriter writer)
         {
-            using (var ms = new MemoryStream())
-            {
-                using (var writer = new EndianBinaryWriter(EndianBitConverter.Big, ms))
-                {
-                    writer.Write(_updates.Count);
-
-                    foreach (var update in _updates)
-                    {
-                        writer.Write(update.Operation);
-                        writer.Write(update.Key);
-
-                        if (update.Operation != RemoveOperation)
-                        {
-                            writer.Write(update.Value);
-                        }
-                    }
-                }
-                return ms.ToArray();
-            }
+            writer.Write(value);
         }
 
-        public override void ApplyUpdates(byte[] data)
+        protected override int ReadValue(EndianBinaryReader reader)
         {
-            using (var ms = new MemoryStream(data))
-            {
-                using (var reader = new EndianBinaryReader(EndianBitConverter.Big,ms))
-                {
-                    var count = reader.ReadInt32();
-
-                    Logs.Error("Updates count: " + count);
-
-                    for (var i = 0; i < count; i++)
-                    {
-                        var operation = reader.ReadByte();
-                        var key = reader.ReadInt32();
-
-                        if (operation == RemoveOperation)
-                        {
-                            _values.Remove(key);
-                            continue;
-                        }
-
-                        var value = reader.ReadInt32();
-
-                        if (_values.ContainsKey(key))
-                        {
-                            _values[key] = value;
-                        }
-                        else
-                        {
-                            _values.Add(key, value);
-                        }
-                    }
-                }
-            }
-
-            MarkDirty();
+            return reader.ReadInt32();
         }
 
-        public override void ClearUpdates()
+        protected override void WriteKey(int key, EndianBinaryWriter writer)
         {
-            _updates.Clear();
+            writer.Write(key);
         }
 
-        private struct UpdateEntry
+        protected override int ReadKey(EndianBinaryReader reader)
         {
-            public byte Operation;
-            public int Key;
-            public int Value;
+            return reader.ReadInt32();
         }
     }
 }

--- a/MasterServerFramework2/Assets/Development/ProfilesTestScript.cs
+++ b/MasterServerFramework2/Assets/Development/ProfilesTestScript.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections;
-using System.Runtime.Remoting.Messaging;
 using Barebones.MasterServer;
 using UnityEngine;
+using System.Collections.Generic;
 
 public class ProfilesTestScript : MonoBehaviour
 {
 
     private string _username;
+    private ObservableDictStringInt _serverInventory;
 
 	// Use this for initialization
 	void Start ()
@@ -24,6 +25,8 @@ public class ProfilesTestScript : MonoBehaviour
         // Get the profiles module
         var profilesModule = FindObjectOfType<ProfilesModule>();
 
+        var initialInventory = new Dictionary<string, int>();
+        initialInventory["Wood"] = 10;
         // Set the profile factory
         profilesModule.ProfileFactory = (username, peer) => new ObservableServerProfile(username)
         {
@@ -31,7 +34,7 @@ public class ProfilesTestScript : MonoBehaviour
             new ObservableInt(MyProfileKeys.Coins, 10),
             new ObservableInt(MyProfileKeys.Score, 0),
             new ObservableString(MyProfileKeys.Title, "DefaultTitle"),
-            new ObservableDictionary(MyProfileKeys.Inventory)
+            new ObservableDictStringInt(MyProfileKeys.Inventory, initialInventory)
             // And so on, and on...
         };
 
@@ -65,6 +68,7 @@ public class ProfilesTestScript : MonoBehaviour
             {
                 new ObservableInt(MyProfileKeys.Coins, 5),
                 new ObservableString(MyProfileKeys.Title, "DefaultTitle"),
+                new ObservableDictStringInt(MyProfileKeys.Inventory),
             };
 
             // Send a request to master server, to fill profile values
@@ -115,6 +119,7 @@ public class ProfilesTestScript : MonoBehaviour
         {
             new ObservableInt(MyProfileKeys.Coins, 5),
             new ObservableString(MyProfileKeys.Title, "DefaultTitle"),
+            new ObservableDictStringInt(MyProfileKeys.Inventory),
         };
 
         // Fill profile values
@@ -129,6 +134,8 @@ public class ProfilesTestScript : MonoBehaviour
             // Modify the profile (changes will automatically be sent to the master server)
             profile.GetProperty<ObservableInt>(MyProfileKeys.Coins).Add(4);
             profile.GetProperty<ObservableString>(MyProfileKeys.Title).Set("DifferentTitle");
+            _serverInventory = profile.GetProperty<ObservableDictStringInt>(MyProfileKeys.Inventory);
+            _serverInventory.SetValue("Wood", _serverInventory.GetValue("Wood") + 10);
 
         }, connection);
 
@@ -136,6 +143,6 @@ public class ProfilesTestScript : MonoBehaviour
 
     // Update is called once per frame
     void Update () {
-		
-	}
+
+    }
 }


### PR DESCRIPTION
This PR introduces a new class which derives from ``ObservableBase``, the ``ObservableBaseDictionary<TKey, TValue>``.

This class avoids repeating the same boilerplate code used in the observable dictionaries by making use of generics. Implementors must override some abstract methods in order to provide specific serialisation logic.

The ``ProfilesTestScript`` has also been modified to include a test with a dictionary.